### PR TITLE
Fix make test target and add CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            libffi-dev \
+            libgmp-dev \
+            libreadline-dev \
+            libsdl2-dev \
+            pkg-config \
+            python3
+      - name: Run tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ BOARD ?= STM32F469DISC
 FLAVOR ?= SPECTER
 USER_C_MODULES ?= ../../../usermods
 MPY_DIR ?= f469-disco/micropython
+MPY_CFLAGS ?= -Wno-dangling-pointer -Wno-enum-int-mismatch
 FROZEN_MANIFEST_DISCO ?= ../../../../manifests/disco.py
 FROZEN_MANIFEST_DEBUG ?= ../../../../manifests/debug.py
 FROZEN_MANIFEST_UNIX ?= ../../../../manifests/unix.py
@@ -20,55 +21,59 @@ $(MPY_DIR)/mpy-cross/Makefile:
 mpy-cross: $(TARGET_DIR) $(MPY_DIR)/mpy-cross/Makefile
 	@echo Building cross-compiler
 	make -C $(MPY_DIR)/mpy-cross \
-	DEBUG=$(DEBUG) && \
+        DEBUG=$(DEBUG) \
+        CFLAGS_EXTRA="$(MPY_CFLAGS)" && \
 	cp $(MPY_DIR)/mpy-cross/mpy-cross $(TARGET_DIR)
 
 # disco board with bitcoin library
 disco: $(TARGET_DIR) mpy-cross $(MPY_DIR)/ports/stm32
 	@echo Building firmware
 	make -C $(MPY_DIR)/ports/stm32 \
-		BOARD=$(BOARD) \
-		FLAVOR=$(FLAVOR) \
-		USE_DBOOT=$(USE_DBOOT) \
-		USER_C_MODULES=$(USER_C_MODULES) \
-		FROZEN_MANIFEST=$(FROZEN_MANIFEST_DISCO) \
-		DEBUG=$(DEBUG) && \
+        BOARD=$(BOARD) \
+        FLAVOR=$(FLAVOR) \
+        USE_DBOOT=$(USE_DBOOT) \
+        USER_C_MODULES=$(USER_C_MODULES) \
+        FROZEN_MANIFEST=$(FROZEN_MANIFEST_DISCO) \
+        DEBUG=$(DEBUG) \
+        CFLAGS_EXTRA="$(MPY_CFLAGS)" && \
 	arm-none-eabi-objcopy -O binary \
-		$(MPY_DIR)/ports/stm32/build-STM32F469DISC/firmware.elf \
-		$(TARGET_DIR)/specter-diy.bin && \
-	cp $(MPY_DIR)/ports/stm32/build-STM32F469DISC/firmware.hex \
-		$(TARGET_DIR)/specter-diy.hex
+        $(MPY_DIR)/ports/stm32/build-STM32F469DISC/firmware.elf \
+        $(TARGET_DIR)/specter-diy.bin && \
+        cp $(MPY_DIR)/ports/stm32/build-STM32F469DISC/firmware.hex \
+                $(TARGET_DIR)/specter-diy.hex
 
 # disco board with bitcoin library
 debug: $(TARGET_DIR) mpy-cross $(MPY_DIR)/ports/stm32
 	@echo Building firmware
 	make -C $(MPY_DIR)/ports/stm32 \
-		BOARD=$(BOARD) \
-		FLAVOR=$(FLAVOR) \
-		USE_DBOOT=$(USE_DBOOT) \
-		USER_C_MODULES=$(USER_C_MODULES) \
-		FROZEN_MANIFEST=$(FROZEN_MANIFEST_DEBUG) \
-		DEBUG=$(DEBUG) && \
+        BOARD=$(BOARD) \
+        FLAVOR=$(FLAVOR) \
+        USE_DBOOT=$(USE_DBOOT) \
+        USER_C_MODULES=$(USER_C_MODULES) \
+        FROZEN_MANIFEST=$(FROZEN_MANIFEST_DEBUG) \
+        DEBUG=$(DEBUG) \
+        CFLAGS_EXTRA="$(MPY_CFLAGS)" && \
 	arm-none-eabi-objcopy -O binary \
-		$(MPY_DIR)/ports/stm32/build-STM32F469DISC/firmware.elf \
-		$(TARGET_DIR)/debug.bin && \
+        $(MPY_DIR)/ports/stm32/build-STM32F469DISC/firmware.elf \
+        $(TARGET_DIR)/debug.bin && \
 	cp $(MPY_DIR)/ports/stm32/build-STM32F469DISC/firmware.hex \
-		$(TARGET_DIR)/debug.hex
+        $(TARGET_DIR)/debug.hex
 
 
 # unixport (simulator)
 unix: $(TARGET_DIR) mpy-cross $(MPY_DIR)/ports/unix
 	@echo Building binary with frozen files
 	make -C $(MPY_DIR)/ports/unix \
-		USER_C_MODULES=$(USER_C_MODULES) \
-		FROZEN_MANIFEST=$(FROZEN_MANIFEST_UNIX) && \
+        USER_C_MODULES=$(USER_C_MODULES) \
+        FROZEN_MANIFEST=$(FROZEN_MANIFEST_UNIX) \
+        CFLAGS_EXTRA="$(MPY_CFLAGS)" && \
 	cp $(MPY_DIR)/ports/unix/micropython $(TARGET_DIR)/micropython_unix
 
 simulate: unix
 	$(TARGET_DIR)/micropython_unix simulate.py
 
 test: unix
-	$(TARGET_DIR)/micropython_unix tests/run_tests.py
+	cd test && ../$(TARGET_DIR)/micropython_unix run_tests.py
 
 all: mpy-cross disco unix
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,20 @@ Specter-Shield documentation and all the files are available in the [`shield/`](
 
 Supported networks: Mainnet, Testnet, Regtest, Signet.
 
+## Running tests
+
+The unit test suite runs on the Unix simulator build. Install the required
+system packages and then run the `make` target:
+
+```
+sudo apt-get update
+sudo apt-get install libsdl2-dev libffi-dev pkg-config libreadline-dev libgmp-dev build-essential python3
+make test
+```
+
+The build system will fetch the necessary submodules and compile the simulator
+before executing the tests.
+
 ## USB communication on Linux
 
 You may need to set up udev rules and add yourself to `dialout` group. Read more in [`udev`](./udev/README.md) folder.


### PR DESCRIPTION
## Summary
- update the Makefile so `make test` builds successfully by forwarding the required compiler flags and running the tests from the correct directory
- document the native dependencies needed to run the simulator test suite locally
- add a GitHub Actions workflow that installs the prerequisites and runs `make test`

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e41ba502288322a33991b492d757e3