### PR TITLE
Add tests for wallet communication parsing

### DIFF
--- a/test/tests/test_wallet_manager_parsing.py
+++ b/test/tests/test_wallet_manager_parsing.py
@@ -1,0 +1,70 @@
+from unittest import TestCase
+from io import BytesIO
+
+from .util import get_keystore, get_wallets_app, clear_testdir
+from apps.wallets.manager import ADD_WALLET, SIGN_PSBT, VERIFY_ADDRESS
+
+DOC_DESCRIPTOR = (
+    "wsh(sortedmulti(2,"
+    "[b317ec86/48h/1h/0h/2h]tpubDEToKMGFhyuP6kfwvjtYaf56khzS1cUcwc47C6aMH6bQ8sNVLMcCK6jr21YDCkU2QhTK5CAnddhfgZ8dD4EL1wGCaAKZaGFeVVdXHaJMTMn,"
+    "[f04828fe/48h/1h/0h/2h]tpubDFekS5zvPSdW6WWjH2p7vPRkxmeeNGnirmj36AUyoAYbJvfKBj6UARWR5gQ6FRrr98dzT1XFTi6rfGo9AAAeutY1S6SoWijQ8BKxDhYQzDR,"
+    "[d3c05b2e/48h/1h/0h/2h]tpubDFnAczXQTHxuBh7FxrpLDHBidkC1Di54pTPSPMu4AQjKziFQQTTEFXEVugqm8ucKQhJfLGesBjRZWtLpqAkAmecoXtvaPwCzf4teqrY7Uu5))"
+)
+DOC_NAMED_DESCRIPTOR = "My multisig&" + DOC_DESCRIPTOR
+DOC_ADDWALLET_COMMAND = "addwallet " + DOC_NAMED_DESCRIPTOR
+DOC_ADDRESS_REQUEST = (
+    "bitcoin:bcrt1qd3mtrhysk3k4w6fmu7ayjvwk6q98c2dpf0p4x87zauu8rcgq5dzq73tyrx?index=2"
+)
+DOC_BASE64_PSBT = (
+    "cHNidP8BAHECAAAAAWzGfenb3RfMnjMnbG3ma7oQc2hXxtwJfVVmgrnWm+4UAQAAAAD9////AtYbLAQAAAAAFgAUrNujDLwLZgayRWvplXj9l9JCeCWAlpgAAAAAABYAFCwSoUTerJLG437IpfbWF8DgWx6kAAAAAAABAHECAAAAAYWnVTba+0vAveezgcq1RYQ/kgJWaR18whFlaiyB21+IAQAAAAD9////AoCWmAAAAAAAFgAULBKhRN6sksbjfsil9tYXwOBbHqTkssQEAAAAABYAFB8nluuilYNXa/NkD0Yl26S/P0uNAAAAAAEBH+SyxAQAAAAAFgAUHyeW66KVg1dr82QPRiXbpL8/S40iBgIaiZEUrL8SsjMa8kjotFVJqjhEQ9YTjOUqkhEyemGmNhj7fB8RVAAAgAEAAIAAAACAAQAAAAIAAAAAIgID2bmiDcc2vHCuHg7T/C0YXLPanHBaS665367wqdHd9AgY+3wfEVQAAIABAACAAAAAgAEAAAAEAAAAAAA="
+)
+
+
+class WalletManagerParsingTest(TestCase):
+    def setUp(self):
+        clear_testdir()
+        self.keystore = get_keystore()
+        self.wallets_app = get_wallets_app(self.keystore, "regtest")
+        self.manager = self.wallets_app.manager
+
+    def tearDown(self):
+        clear_testdir()
+
+    def _parse_command(self, data):
+        stream = BytesIO(data)
+        cmd, result_stream = self.manager.parse_stream(stream)
+        self.assertIs(result_stream, stream)
+        return cmd, result_stream
+
+    def test_docs_addwallet_command_is_detected(self):
+        cmd, stream = self._parse_command(DOC_ADDWALLET_COMMAND.encode())
+        self.assertEqual(cmd, ADD_WALLET)
+        self.assertEqual(stream.read().decode(), DOC_NAMED_DESCRIPTOR)
+
+    def test_descriptor_without_addwallet_prefix_is_parsed(self):
+        cmd, stream = self._parse_command(DOC_NAMED_DESCRIPTOR.encode())
+        self.assertEqual(cmd, ADD_WALLET)
+        self.assertEqual(stream.read().decode(), DOC_NAMED_DESCRIPTOR)
+        wallet = self.manager.parse_wallet(DOC_NAMED_DESCRIPTOR)
+        self.assertEqual(wallet.name, "My multisig")
+        self.assertEqual(str(wallet.descriptor), DOC_DESCRIPTOR)
+
+    def test_raw_descriptor_is_parsed(self):
+        cmd, stream = self._parse_command(DOC_DESCRIPTOR.encode())
+        self.assertEqual(cmd, ADD_WALLET)
+        self.assertEqual(stream.read().decode(), DOC_DESCRIPTOR)
+        wallet = self.manager.parse_wallet(DOC_DESCRIPTOR)
+        self.assertEqual(wallet.name, "Untitled")
+        self.assertEqual(str(wallet.descriptor), DOC_DESCRIPTOR)
+
+    def test_docs_base64_psbt_is_detected(self):
+        cmd, stream = self._parse_command(DOC_BASE64_PSBT.encode())
+        self.assertEqual(cmd, SIGN_PSBT)
+        # ensure stream is rewound for later processing
+        self.assertEqual(stream.read(10), DOC_BASE64_PSBT[:10].encode())
+
+    def test_docs_address_request_is_detected(self):
+        cmd, stream = self._parse_command(DOC_ADDRESS_REQUEST.encode())
+        self.assertEqual(cmd, VERIFY_ADDRESS)
+        # parse_stream should keep address data available for processing
+        self.assertEqual(stream.read().decode(), DOC_ADDRESS_REQUEST.replace("bitcoin:", "", 1))


### PR DESCRIPTION
## Summary
- add unit tests covering wallet manager parsing of addwallet commands, descriptors, base64 PSBTs, and address verification data

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e43d2fb7948322b05257734c42b9bb