### PR TITLE
Adjust settings note and include build metadata in About screen

### DIFF
--- a/boot/debug/boot.py
+++ b/boot/debug/boot.py
@@ -39,6 +39,8 @@ pyb.ExtInt(pyb.Pin('B1'), pyb.ExtInt.IRQ_FALLING, pyb.Pin.PULL_NONE, pwrcb)
 # inject version to platform module
 import platform
 platform.version = version
+platform.bootloader_locked = False
+platform.build_type = "debug"
 
 # uncomment to run some custom main:
 pyb.main("hardwaretest.py")

--- a/boot/main/boot.py
+++ b/boot/main/boot.py
@@ -62,3 +62,5 @@ os.dupterm(None,1)
 import platform
 platform.version = version
 platform.i2c = i2c
+platform.bootloader_locked = True
+platform.build_type = "disco"

--- a/src/platform.py
+++ b/src/platform.py
@@ -6,6 +6,16 @@ import gc
 
 simulator = (sys.platform in ["linux", "darwin"])
 
+
+# Build metadata injected at boot time. Defaults represent the minimum
+# information we can know without platform-specific boot scripts.
+bootloader_locked = None
+build_type = "unknown"
+
+if simulator:
+    build_type = "unix"
+    bootloader_locked = False
+
 try:
     import config
 except:
@@ -153,6 +163,18 @@ def get_version() -> str:
         return ver
     except:
         return "unknown"
+
+
+def get_bootloader_lock_status() -> str:
+    if bootloader_locked is True:
+        return "locked"
+    if bootloader_locked is False:
+        return "unlocked"
+    return "unknown"
+
+
+def get_build_type() -> str:
+    return build_type
 
 def mount_sdram():
     path = fpath("/ramdisk")

--- a/src/specter.py
+++ b/src/specter.py
@@ -70,9 +70,14 @@ class Specter:
         if commit != "unknown":
             note_lines.append("Commit: %s" % commit)
 
+        def _format_status(value):
+            if isinstance(value, str) and value:
+                return value[0].upper() + value[1:]
+            return value
+
         bootloader_status = get_bootloader_lock_status()
         if bootloader_status != "unknown":
-            bootloader_note = "Bootloader lock: %s" % bootloader_status.capitalize()
+            bootloader_note = "Bootloader lock: %s" % _format_status(bootloader_status)
         else:
             bootloader_note = "Bootloader lock: Unknown"
         note_lines.append(bootloader_note)
@@ -81,7 +86,7 @@ class Specter:
         if build_type == "unknown":
             build_note = "Build type: Unknown"
         else:
-            build_note = "Build type: %s" % build_type.capitalize()
+            build_note = "Build type: %s" % _format_status(build_type)
         note_lines.append(build_note)
 
         return "\n".join(note_lines)


### PR DESCRIPTION
## Summary
- expose build type and bootloader lock metadata through the platform module
- limit settings-related menus to show only the firmware version banner
- expand the About dialog with repository, commit, bootloader, and build type details

## Testing
- python -m compileall src/specter.py src/platform.py

------
https://chatgpt.com/codex/tasks/task_e_68ea4b92f248832294f854287eda8652