### PR TITLE
Expand address verification for raw address QR scans

### DIFF
--- a/src/apps/wallets/manager.py
+++ b/src/apps/wallets/manager.py
@@ -330,6 +330,7 @@ class WalletManager(BaseApp):
 
         start_idx = 0
         branches = wallet.descriptor.num_branches
+        gui_loader = getattr(self.show_loader, "__self__", None)
         while True:
             end_idx = start_idx + batch_size - 1
             self.show_loader(
@@ -348,7 +349,8 @@ class WalletManager(BaseApp):
                     if found is not None:
                         break
             finally:
-                self.hide_loader()
+                if gui_loader is not None and hasattr(gui_loader, "hide_loader"):
+                    gui_loader.hide_loader()
 
             if found is not None:
                 idx, branch_idx = found
@@ -359,16 +361,15 @@ class WalletManager(BaseApp):
                 )
                 return True
 
+            message = (
+                "The address %s was not found between indexes %d and %d.\n\n"
+                "Check the next %d addresses?"
+                % (addr_to_check, start_idx, end_idx, batch_size)
+            )
             cont = await show_screen(
                 Prompt(
                     "Address not found",
-                    "The address %s was not found between indexes %d and %d.\n\n"
-                    "Check the next %d addresses?" % (
-                        addr_to_check,
-                        start_idx,
-                        end_idx,
-                        batch_size,
-                    ),
+                    message,
                     confirm_text="Next %d" % batch_size,
                     cancel_text="Abort",
                 )

--- a/src/apps/wallets/manager.py
+++ b/src/apps/wallets/manager.py
@@ -186,6 +186,22 @@ class WalletManager(BaseApp):
             else:
                 stream.seek(0)
             return VERIFY_ADDRESS, stream
+        # probably raw bitcoin address (base58 or bech32)
+        try:
+            txt = data.decode().strip()
+        except UnicodeDecodeError:
+            txt = ""
+        if txt:
+            addr_chars = set(
+                "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+            )
+            bech32_chars = set("023456789acdefghjklmnpqrstuvwxyz")
+            addr_chars |= {c.upper() for c in bech32_chars}
+            addr_chars |= bech32_chars
+            candidate = txt.split("\n")[0].strip()
+            if candidate and all(c in addr_chars for c in candidate):
+                stream.seek(0)
+                return VERIFY_ADDRESS, stream
 
         return None, None
 
@@ -244,20 +260,31 @@ class WalletManager(BaseApp):
                 self.add_wallet(w)
             return bool(confirm)
         elif cmd == VERIFY_ADDRESS:
-            data = stream.read().decode().replace("bitcoin:", "")
-            # should be of the form addr?index=N or similar
-            if "index=" not in data or "?" not in data:
-                raise WalletError("Can't verify address with unknown index")
-            addr, rest = data.split("?")
-            args = rest.split("&")
+            raw = stream.read().decode().strip()
+            if raw.lower().startswith("bitcoin:"):
+                raw = raw.split(":", 1)[1]
+            addr_part = raw
+            query = ""
+            if "?" in raw:
+                addr_part, query = raw.split("?", 1)
+            addr_part = addr_part.strip()
+            if not addr_part:
+                raise WalletError("Can't verify address with unknown value")
             idx = None
-            for arg in args:
-                if arg.startswith("index="):
-                    idx = int(arg[6:])
-                    break
-            w, _ = self.find_wallet_from_address(addr, index=idx)
-            await show_screen(WalletScreen(w, self.network, idx))
-            return True
+            if query:
+                for arg in query.split("&"):
+                    if arg.startswith("index="):
+                        idx = int(arg[6:])
+                        break
+            if idx is not None:
+                w, _ = self.find_wallet_from_address(addr_part, index=idx)
+                await show_screen(WalletScreen(w, self.network, idx))
+                return True
+
+            wallet = await self.select_wallet_for_verification(show_screen)
+            if wallet is None:
+                return False
+            return await self.verify_address_in_wallet(wallet, addr_part, show_screen)
         elif cmd == DERIVE_ADDRESS:
             arr = stream.read().split(b" ")
             redeem_script = None
@@ -276,6 +303,79 @@ class WalletManager(BaseApp):
             return BytesIO(res), {}
         else:
             raise WalletError("Unknown command")
+
+    async def select_wallet_for_verification(self, show_screen):
+        if not self.wallets:
+            raise WalletError("No wallets available")
+        buttons = [(w, w.name) for w in self.wallets]
+        menu = Menu(
+            buttons,
+            last=(255, None),
+            title="Select wallet",
+            note="Choose a wallet to check the scanned address.",
+        )
+        selection = await show_screen(menu)
+        if selection == 255:
+            return None
+        return selection
+
+    async def verify_address_in_wallet(self, wallet, address, show_screen, batch_size=25):
+        addr_to_check = address.strip()
+        if addr_to_check.lower().startswith(("bc1", "tb1", "bcrt1")):
+            target = addr_to_check.lower()
+            normalize = lambda a: a.lower()
+        else:
+            target = addr_to_check
+            normalize = lambda a: a
+
+        start_idx = 0
+        branches = wallet.descriptor.num_branches
+        while True:
+            end_idx = start_idx + batch_size - 1
+            self.show_loader(
+                title="Checking addresses %d-%d..." % (start_idx, end_idx)
+            )
+            found = None
+            try:
+                for branch_idx in range(branches):
+                    for idx in range(start_idx, start_idx + batch_size):
+                        candidate, _ = wallet.get_address(
+                            idx, self.network, branch_idx
+                        )
+                        if normalize(candidate) == target:
+                            found = (idx, branch_idx)
+                            break
+                    if found is not None:
+                        break
+            finally:
+                self.hide_loader()
+
+            if found is not None:
+                idx, branch_idx = found
+                await show_screen(
+                    WalletScreen(
+                        wallet, self.network, idx, branch_index=branch_idx
+                    )
+                )
+                return True
+
+            cont = await show_screen(
+                Prompt(
+                    "Address not found",
+                    "The address %s was not found between indexes %d and %d.\n\n"
+                    "Check the next %d addresses?" % (
+                        addr_to_check,
+                        start_idx,
+                        end_idx,
+                        batch_size,
+                    ),
+                    confirm_text="Next %d" % batch_size,
+                    cancel_text="Abort",
+                )
+            )
+            if not cont:
+                return False
+            start_idx += batch_size
 
     async def sign_psbt(self, stream, show_screen, encoding=BASE64_STREAM):
         if encoding == BASE64_STREAM:


### PR DESCRIPTION
## Summary
- detect raw Bitcoin address QR scans and route them to the verification flow
- prompt the user to choose a wallet when no index hint is provided
- iterate through wallet addresses in configurable batches, offering to search further until a match or abort

## Testing
- python -m compileall src/apps/wallets/manager.py

------
https://chatgpt.com/codex/tasks/task_e_68ec0317da0c832295e0d52b58114512