### PR TITLE
Add shield documentation links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Specter-Shield documentation and all the files are available in the [`shield/`](
 - [What it looks like](./shield/README.md)
 - [How to print a 3d case](./shield/3dprinting.md)
 
+Specter Shield-Lite documentation is available in the [`shield-lite/`](./shield-lite) folder:
+
+- [Specter Shield-Lite overview](./shield-lite/readme.md)
+
 Supported networks: Mainnet, Testnet, Regtest, Signet.
 
 ## USB communication on Linux


### PR DESCRIPTION
## Summary
- link to the Specter Shield documentation from the main README
- add a reference to the Specter Shield-Lite documentation overview

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3d0f39cd88322b20541254aba6d8f