### PR TITLE
Update QR module reset button label

### DIFF
--- a/src/hosts/qr.py
+++ b/src/hosts/qr.py
@@ -464,7 +464,7 @@ class QRHost(Host):
             scr.set_value("factory_reset")
 
         reset_btn = add_button(
-            lv.SYMBOL.REFRESH + " Factory reset",
+            lv.SYMBOL.REFRESH + " Reset QR Module",
             on_release(trigger_factory_reset),
             scr=scr.page,
             y=reset_y,


### PR DESCRIPTION
## Summary
- update the QR module settings button label to say "Reset QR Module"

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690b85e39cac8322afdf4789e618de37