### PR TITLE
Update critical error wipe confirmation label

### DIFF
--- a/src/gui/async_gui.py
+++ b/src/gui/async_gui.py
@@ -156,9 +156,9 @@ class AsyncGUI:
         await self.load_screen(alert)
         return await alert.result()
 
-    async def error(self, msg, popup=False):
+    async def error(self, msg, popup=False, button_text="OK"):
         """Shows an error"""
-        alert = Alert("Error!", msg, button_text="OK")
+        alert = Alert("Error!", msg, button_text=button_text)
         if popup:
             await self.open_popup(alert)
         else:

--- a/src/specter.py
+++ b/src/specter.py
@@ -73,7 +73,10 @@ class Specter:
             raise exception
         except CriticalErrorWipeImmediately as e:
             # show error
-            await self.gui.error("Critical error, the device will be wiped.\n\n%s" % e)
+            await self.gui.error(
+                "Critical error, the device will be wiped.\n\n%s" % e,
+                button_text="Wipe Specter Device",
+            )
             self.gui.show_loader(title="Wiping the device...")
             # wipe everything and reboot
             self.wipe()


### PR DESCRIPTION
## Summary
- allow the generic error dialog to accept a custom button label
- label the critical wipe confirmation button as "Wipe Specter Device"

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690bd6ae36b88322b3574f61aad47ef0